### PR TITLE
Add macOS Eisenhower grid app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "GridMinders",
+    platforms: [
+        .macOS(.v11)
+    ],
+    products: [
+        .executable(name: "GridMinders", targets: ["GridMinders"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "GridMinders",
+            path: "Sources/GridMinders"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GridMinders is a simple macOS SwiftUI app that visualizes your Apple Reminders i
 
 The app requests permission to access the Reminders database using `EventKit`. Tasks are categorized as:
 
-- **Important** if they are flagged or have high priority.
+- **Important** if they have the highest priority.
 - **Urgent** if they are due today or within the next 24 hours.
 
 The four quadrants are:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GridMinders
 
 GridMinders is a simple macOS SwiftUI app that visualizes your Apple Reminders in an Eisenhower 2x2 grid.
+The reminders list updates automatically whenever tasks change in the Reminders app, so the grid stays current.
 
 The app requests permission to access the Reminders database using `EventKit`. Tasks are categorized as:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# GridMinders
 
+GridMinders is a simple macOS SwiftUI app that visualizes your Apple Reminders in an Eisenhower 2x2 grid.
+
+The app requests permission to access the Reminders database using `EventKit`. Tasks are categorized as:
+
+- **Important** if they are flagged or have high priority.
+- **Urgent** if they are due today or within the next 24 hours.
+
+The four quadrants are:
+
+1. Important & Urgent
+2. Important & Not Urgent
+3. Not Important & Urgent
+4. Not Important & Not Urgent
+
+## Building
+
+The project is a Swift Package. Open the directory in Xcode (12 or later) or build from the command line:
+
+```bash
+swift build
+```
+
+Running the resulting executable will launch the GridMinders app.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # GridMinders
 
 GridMinders is a simple macOS SwiftUI app that visualizes your Apple Reminders in an Eisenhower 2x2 grid.
-The reminders list updates automatically whenever tasks change in the Reminders app, so the grid stays current.
+The reminders list updates automatically whenever tasks change in the Reminders app or sync via iCloud, so the grid stays current.
 
-The app requests permission to access the Reminders database using `EventKit`. Tasks are categorized as:
+The app requests permission to access the Reminders database using `EventKit`. Completed tasks are filtered out so only open reminders appear. Tasks are categorized as:
 
 - **Important** if they have the highest priority.
 - **Urgent** if they are due today or within the next 24 hours.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The four quadrants are:
 3. Not Important & Urgent
 4. Not Important & Not Urgent
 
+Click the checkmark next to a task to mark it complete. Double-click a task to open it directly in the Reminders app.
+
 ## Building
 
 The project is a Swift Package. Open the directory in Xcode (12 or later) or build from the command line:

--- a/Sources/GridMinders/GridMindersApp.swift
+++ b/Sources/GridMinders/GridMindersApp.swift
@@ -7,7 +7,7 @@ struct GridMindersApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ReminderGridView(reminders: fetcher.reminders)
+            ReminderGridView(fetcher: fetcher)
                 .onAppear {
                     fetcher.requestAccess()
                 }

--- a/Sources/GridMinders/GridMindersApp.swift
+++ b/Sources/GridMinders/GridMindersApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import EventKit
+
+@main
+struct GridMindersApp: App {
+    @StateObject private var fetcher = ReminderFetcher()
+
+    var body: some Scene {
+        WindowGroup {
+            ReminderGridView(reminders: fetcher.reminders)
+                .onAppear {
+                    fetcher.requestAccess()
+                }
+        }
+    }
+}

--- a/Sources/GridMinders/ReminderFetcher.swift
+++ b/Sources/GridMinders/ReminderFetcher.swift
@@ -4,6 +4,15 @@ import Combine
 final class ReminderFetcher: ObservableObject {
     @Published private(set) var reminders: [EKReminder] = []
     private let store = EKEventStore()
+    private var changeCancellable: AnyCancellable?
+
+    init() {
+        changeCancellable = NotificationCenter.default.publisher(for: .EKEventStoreChanged, object: store)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.loadReminders()
+            }
+    }
 
     func requestAccess() {
         store.requestAccess(to: .reminder) { granted, _ in

--- a/Sources/GridMinders/ReminderFetcher.swift
+++ b/Sources/GridMinders/ReminderFetcher.swift
@@ -1,0 +1,24 @@
+import EventKit
+import Combine
+
+final class ReminderFetcher: ObservableObject {
+    @Published private(set) var reminders: [EKReminder] = []
+    private let store = EKEventStore()
+
+    func requestAccess() {
+        store.requestAccess(to: .reminder) { granted, _ in
+            if granted {
+                self.loadReminders()
+            }
+        }
+    }
+
+    private func loadReminders() {
+        let predicate = store.predicateForReminders(in: nil)
+        store.fetchReminders(matching: predicate) { reminders in
+            DispatchQueue.main.async {
+                self.reminders = reminders ?? []
+            }
+        }
+    }
+}

--- a/Sources/GridMinders/ReminderFetcher.swift
+++ b/Sources/GridMinders/ReminderFetcher.swift
@@ -33,4 +33,14 @@ final class ReminderFetcher: ObservableObject {
             }
         }
     }
+
+    func complete(_ reminder: EKReminder) {
+        reminder.isCompleted = true
+        do {
+            try store.save(reminder, commit: true)
+            loadReminders()
+        } catch {
+            print("Failed to complete reminder", error)
+        }
+    }
 }

--- a/Sources/GridMinders/ReminderGridView.swift
+++ b/Sources/GridMinders/ReminderGridView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import EventKit
+
+struct ReminderGridView: View {
+    var reminders: [EKReminder]
+
+    private func categorize(_ reminder: EKReminder) -> (important: Bool, urgent: Bool) {
+        let important = reminder.isFlagged || reminder.priority == 1
+        var urgent = false
+        if let due = reminder.dueDateComponents?.date {
+            urgent = Calendar.current.isDateInToday(due) || due < Date().addingTimeInterval(24*60*60)
+        }
+        return (important, urgent)
+    }
+
+    private func quadrant(_ reminder: EKReminder) -> Int {
+        let result = categorize(reminder)
+        switch (result.important, result.urgent) {
+        case (true, true): return 1
+        case (true, false): return 2
+        case (false, true): return 3
+        default: return 4
+        }
+    }
+
+    var body: some View {
+        let q1 = reminders.filter { quadrant($0) == 1 }
+        let q2 = reminders.filter { quadrant($0) == 2 }
+        let q3 = reminders.filter { quadrant($0) == 3 }
+        let q4 = reminders.filter { quadrant($0) == 4 }
+
+        return VStack {
+            HStack {
+                quadrantView(title: "Important & Urgent", reminders: q1)
+                quadrantView(title: "Important & Not Urgent", reminders: q2)
+            }
+            HStack {
+                quadrantView(title: "Not Important & Urgent", reminders: q3)
+                quadrantView(title: "Not Important & Not Urgent", reminders: q4)
+            }
+        }
+        .padding()
+    }
+
+    private func quadrantView(title: String, reminders: [EKReminder]) -> some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.headline)
+            List(reminders, id: \.calendarItemIdentifier) { reminder in
+                Text(reminder.title)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .border(Color.gray)
+    }
+}

--- a/Sources/GridMinders/ReminderGridView.swift
+++ b/Sources/GridMinders/ReminderGridView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import EventKit
+import AppKit
 
 struct ReminderGridView: View {
     @ObservedObject var fetcher: ReminderFetcher
@@ -50,7 +51,20 @@ struct ReminderGridView: View {
             Text(title)
                 .font(.headline)
             List(reminders, id: \.calendarItemIdentifier) { reminder in
-                Text(reminder.title)
+                HStack {
+                    Button(action: {
+                        fetcher.complete(reminder)
+                    }) {
+                        Image(systemName: "checkmark.circle")
+                    }
+                    .buttonStyle(BorderlessButtonStyle())
+                    Text(reminder.title)
+                }
+                .onTapGesture(count: 2) {
+                    if let url = URL(string: "x-apple-reminder://\(reminder.calendarItemIdentifier)") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
             }
         }
         .frame(maxWidth: .infinity)

--- a/Sources/GridMinders/ReminderGridView.swift
+++ b/Sources/GridMinders/ReminderGridView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import EventKit
 
 struct ReminderGridView: View {
-    var reminders: [EKReminder]
+    @ObservedObject var fetcher: ReminderFetcher
 
     private func categorize(_ reminder: EKReminder) -> (important: Bool, urgent: Bool) {
         // EventKit does not expose the "flagged" state, so we only
@@ -26,10 +26,11 @@ struct ReminderGridView: View {
     }
 
     var body: some View {
-        let q1 = reminders.filter { quadrant($0) == 1 }
-        let q2 = reminders.filter { quadrant($0) == 2 }
-        let q3 = reminders.filter { quadrant($0) == 3 }
-        let q4 = reminders.filter { quadrant($0) == 4 }
+        let list = fetcher.reminders
+        let q1 = list.filter { quadrant($0) == 1 }
+        let q2 = list.filter { quadrant($0) == 2 }
+        let q3 = list.filter { quadrant($0) == 3 }
+        let q4 = list.filter { quadrant($0) == 4 }
 
         return VStack {
             HStack {

--- a/Sources/GridMinders/ReminderGridView.swift
+++ b/Sources/GridMinders/ReminderGridView.swift
@@ -5,7 +5,9 @@ struct ReminderGridView: View {
     var reminders: [EKReminder]
 
     private func categorize(_ reminder: EKReminder) -> (important: Bool, urgent: Bool) {
-        let important = reminder.isFlagged || reminder.priority == 1
+        // EventKit does not expose the "flagged" state, so we only
+        // treat reminders with the highest priority as important.
+        let important = reminder.priority == 1
         var urgent = false
         if let due = reminder.dueDateComponents?.date {
             urgent = Calendar.current.isDateInToday(due) || due < Date().addingTimeInterval(24*60*60)


### PR DESCRIPTION
## Summary
- set up a Swift Package for a macOS app
- implement the SwiftUI app using EventKit reminders
- categorize reminders into Eisenhower quadrants
- document building and running

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684af0c2d7148325996eab4fb0207534