### PR TITLE
Implement drag and drop reclassification for reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ The four quadrants are:
 4. Not Important & Not Urgent
 
 Click the checkmark next to a task to mark it complete. Double-click a task to open it directly in the Reminders app.
-You can also drag a reminder from one quadrant to another. Dropping a reminder
-into an important quadrant automatically marks it high priority. Dropping one
-into an urgent quadrant assigns it a due date of today.
+You can also drag a reminder from one quadrant to another:
+- Dropping a reminder into an important quadrant automatically marks it high
+  priority.
+- Dropping one into an urgent quadrant assigns it a due date of today.
+- Dragging an urgent reminder into a non‑urgent quadrant removes its due date.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The four quadrants are:
 4. Not Important & Not Urgent
 
 Click the checkmark next to a task to mark it complete. Double-click a task to open it directly in the Reminders app.
+You can also drag a reminder from one quadrant to another. Dropping a reminder
+into an important quadrant automatically marks it high priority. Dropping one
+into an urgent quadrant assigns it a due date of today.
 
 ## Building
 

--- a/Sources/GridMinders/ReminderFetcher.swift
+++ b/Sources/GridMinders/ReminderFetcher.swift
@@ -48,15 +48,17 @@ final class ReminderFetcher: ObservableObject {
     /// - Parameters:
     ///   - reminder: The reminder to modify.
     ///   - important: If true, the reminder is given the highest priority.
-    ///   - urgent: If true, the reminder is assigned a due date of today.
+    ///   - urgent: If true, the reminder is assigned a due date of today. If
+    ///     false, any existing due date is cleared.
     func modify(_ reminder: EKReminder, important: Bool, urgent: Bool) {
-        if important {
-            reminder.priority = 1
-        }
+        reminder.priority = important ? 1 : 0
 
         if urgent {
-            let comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+            let comps = Calendar.current.dateComponents([.year, .month, .day],
+                                                      from: Date())
             reminder.dueDateComponents = comps
+        } else {
+            reminder.dueDateComponents = nil
         }
 
         do {

--- a/Sources/GridMinders/ReminderFetcher.swift
+++ b/Sources/GridMinders/ReminderFetcher.swift
@@ -43,4 +43,27 @@ final class ReminderFetcher: ObservableObject {
             print("Failed to complete reminder", error)
         }
     }
+
+    /// Update a reminder's importance and urgency based on drag and drop.
+    /// - Parameters:
+    ///   - reminder: The reminder to modify.
+    ///   - important: If true, the reminder is given the highest priority.
+    ///   - urgent: If true, the reminder is assigned a due date of today.
+    func modify(_ reminder: EKReminder, important: Bool, urgent: Bool) {
+        if important {
+            reminder.priority = 1
+        }
+
+        if urgent {
+            let comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+            reminder.dueDateComponents = comps
+        }
+
+        do {
+            try store.save(reminder, commit: true)
+            loadReminders()
+        } catch {
+            print("Failed to modify reminder", error)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- update README with drag and drop instructions
- enable drag and drop in ReminderGridView
- add modify logic in ReminderFetcher to change priority and due date

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684afb187fdc83258f04db17bb507589